### PR TITLE
Add attendance links to admin menu

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -42,6 +42,18 @@
     <li><a href="/report/student_emails?{{ session_query }}">Student Emails</a></li>
     <!--<li><a href="/class_demand?{{ session_query }}">Stub (Class Demand)</a>-->
   </ul>
+  <h3>Attendance</h3>
+  <ul>
+    <li>
+      <a href="/teacher/take_attendance?{{ session_query }}">Take Attendance</a>
+    </li>
+    <li>
+      <a href="/teacher/view_attendance?{{ session_query }}">View Attendance</a>
+    </li>
+    <li>
+      <a href="/teacher/view_by_homeroom?{{ session_query }}">View By Homeroom</a>
+    </li>
+  </ul>
   <h3>Manual Process</h3>
   <ul>
     <li><a href="/report/signup_card?{{ session_query }}">Sign Up Card</a></li>

--- a/teacher/take_attendance.html
+++ b/teacher/take_attendance.html
@@ -1,4 +1,8 @@
-{% extends 'menu_teacher.html' %}
+{% if user_type == 'Admin' %}
+  {% extends 'menu.html' %}
+{% elif user_type == 'Teacher' %}
+  {% extends 'menu_teacher.html' %}
+{% endif %}
 {% block session_body %}
 
 <script>
@@ -360,9 +364,6 @@ window.onload = function() {
 }
 </script>
 
-{% if not teacher %}
-Teacher not found! This error should never happen. Please inform the selectives team. Thanks!
-{% else %}
 <h3 style="margin-bottom:4px; margin-top:4px">Attendance</h3>
 <p id="instructions">Classes that you teach or assist in are listed first; other classes are listed below the dashed line.<br>
 If you would like to be added as an instructor or assistant to a class, please email selectives@discoveryk8.org.
@@ -390,5 +391,4 @@ If you would like to be added as an instructor or assistant to a class, please e
   <div id="attend-buttons"><input type="button" id="attend-edit" value="Edit">
   <input type="button" id="attend-submit" value="Submit"></div>
 </div>
-{% endif %}
 {% endblock %}

--- a/teacher/view_attendance.html
+++ b/teacher/view_attendance.html
@@ -1,4 +1,8 @@
-{% extends 'menu_teacher.html' %}
+{% if user_type == 'Admin' %}
+  {% extends 'menu.html' %}
+{% elif user_type == 'Teacher' %}
+  {% extends 'menu_teacher.html' %}
+{% endif %}
 {% block session_body %}
 
 <script>
@@ -160,9 +164,6 @@ window.onload = function() {
 }
 </script>
 
-{% if not teacher %}
-<div>Teacher not found! This error should never happen.<br>Please inform the selectives team: <a href="mailto:selectives@discoveryk8.org">selectives@discoveryk8.org</a></div>
-{% else %}
 <h3 id="myHeader" style="margin-top:4px; margin-bottom:4px">View Attendance</h3>
 <div>
   <div id="instructions" style="margin-top:5px; margin-bottom:7px">Newer data may be available. Refresh the page to see the most up-to-date attendance as this page does not refresh automatically.
@@ -173,5 +174,4 @@ window.onload = function() {
   </div>
   <div id="absences"></div>
 </div>
-{% endif %}
 {% endblock %}

--- a/teacher/view_attendance.py
+++ b/teacher/view_attendance.py
@@ -38,9 +38,16 @@ def augmentClass(institution, session, c, students):
 class ViewAttendance(webapp2.RequestHandler):
   def get(self):
     auth = authorizer.Authorizer(self)
-    if not auth.HasTeacherAccess():
+    if not (auth.CanAdministerInstitutionFromUrl() or
+            auth.HasTeacherAccess()):
       auth.Redirect()
       return
+
+    user_type = 'None'
+    if auth.CanAdministerInstitutionFromUrl():
+      user_type = 'Admin'
+    elif auth.HasTeacherAccess():
+      user_type = 'Teacher'
 
     institution = self.request.get("institution")
     if not institution:
@@ -78,11 +85,11 @@ class ViewAttendance(webapp2.RequestHandler):
     classes_to_display.sort(key=alphaOrder)
 
     template_values = {
+      'user_type' : user_type,
       'user_email' : auth.email,
       'institution' : institution,
       'session' : session,
       'session_query': session_query,
-      'teacher': auth.teacher_entity,
       'dayparts' : dayparts,
       'selected_daypart': selected_daypart,
       'classes': classes_to_display,

--- a/teacher/view_by_homeroom.html
+++ b/teacher/view_by_homeroom.html
@@ -1,4 +1,8 @@
-{% extends 'menu_teacher.html' %}
+{% if user_type == 'Admin' %}
+  {% extends 'menu.html' %}
+{% elif user_type == 'Teacher' %}
+  {% extends 'menu_teacher.html' %}
+{% endif %}
 {% block session_body %}
 
 <script>
@@ -194,9 +198,6 @@ window.onload = function() {
 }
 </script>
 
-{% if not teacher %}
-Teacher not found! This error should never happen. Please inform the selectives team. Thanks!
-{% else %}
 <h3 id="myHeader" style="margin-top:4px; margin-bottom:4px">View Attendance By Homeroom</h3>
 <div>
   <div id="instructions" style="margin-top:5px; margin-bottom:7px">Newer data may be available. Refresh the page to see the most up-to-date attendance as this page does not refresh automatically.
@@ -209,5 +210,4 @@ Teacher not found! This error should never happen. Please inform the selectives 
   </div>
   <div id="absences"></div>
 </div>
-{% endif %}
 {% endblock %}

--- a/teacher/view_by_homeroom.py
+++ b/teacher/view_by_homeroom.py
@@ -23,9 +23,16 @@ def alphaOrder(c):
 class ViewByHomeroom(webapp2.RequestHandler):
   def get(self):
     auth = authorizer.Authorizer(self)
-    if not auth.HasTeacherAccess():
+    if not (auth.CanAdministerInstitutionFromUrl() or
+            auth.HasTeacherAccess()):
       auth.Redirect()
       return
+
+    user_type = 'None'
+    if auth.CanAdministerInstitutionFromUrl():
+      user_type = 'Admin'
+    elif auth.HasTeacherAccess():
+      user_type = 'Teacher'
 
     institution = self.request.get("institution")
     if not institution:
@@ -92,11 +99,11 @@ class ViewByHomeroom(webapp2.RequestHandler):
       classes_by_homeroom[selected_homeroom] = getClassesByHomeroom(int(selected_homeroom))
 
     template_values = {
+      'user_type' : user_type,
       'user_email' : auth.email,
       'institution' : institution,
       'session' : session,
       'session_query': session_query,
-      'teacher': auth.teacher_entity,
       'dayparts' : dayparts,
       'selected_daypart': selected_daypart,
       'selected_homeroom': selected_homeroom,


### PR DESCRIPTION
The teacher portal has three new pages for taking and viewing attendance. Add these pages to the Admin portal so the admin can directly view these pages instead of logging in as a teacher.

If the admin takes attendance for another teacher and the admin is included in the teacher yaml list, their full name will be stored with the attendance object. Otherwise, the admin's email will be used since we don't store the admin's name anywhere.